### PR TITLE
Widget is broken in alloy v1.0.0-cr

### DIFF
--- a/app/widgets/nl.fokkezb.dynamicScrolling/controllers/widget.js
+++ b/app/widgets/nl.fokkezb.dynamicScrolling/controllers/widget.js
@@ -64,12 +64,12 @@ function doInit(args) {
 	options.table.footerView = $.footerView;
 	options.table.footerView.height = 0;
 	
-	options.table.on('scroll', doScroll);
+	options.table.addEventListener('scroll', doScroll);
 }
 
 function doRemove() {
 	options.table.footerView = null;
-	options.table.off('scroll', doScroll);
+	options.table.removeEventListener('scroll', doScroll);
 	
 	options = null;
 	height = null;


### PR DESCRIPTION
Alloy has removed on and off methods on UI components. Using titanium methods now
