### PR TITLE
Bug fix: Multiple trigger events at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The *DynamicScrolling* widget is an [Alloy](http://projects.appcelerator.com/all
 
 ```javascript
 	"dependencies": {
-		"nl.fokkezb.dynamicScrolling":"1.0"
+		"nl.fokkezb.dynamicScrolling":"1.1"
 	}
 ```
 
@@ -75,5 +75,6 @@ You can also manually *show* and *hide* the view, undo the *init* completely or 
 | remove   |            | Undo the init |
 
 ## Changelog
+* 1.1: Fixed multiple trigger events at once
 * 1.0.1: Fixed for Alloy 1.0GA
 * 1.0: Initial version

--- a/app/widgets/nl.fokkezb.dynamicScrolling/controllers/widget.js
+++ b/app/widgets/nl.fokkezb.dynamicScrolling/controllers/widget.js
@@ -50,7 +50,10 @@ function doTrigger() {
 function finishLoading() {
     doHide();
     
-    loading = false;
+    //ensure no multiple trigger events
+    setTimeout(function(){
+    	loading = false;	
+    },500);
 }
 
 function doInit(args) {

--- a/app/widgets/nl.fokkezb.dynamicScrolling/docs/README.md
+++ b/app/widgets/nl.fokkezb.dynamicScrolling/docs/README.md
@@ -24,7 +24,7 @@ The *DynamicScrolling* widget is an [Alloy](http://projects.appcelerator.com/all
 
 ```javascript
 	"dependencies": {
-		"nl.fokkezb.dynamicScrolling":"1.0"
+		"nl.fokkezb.dynamicScrolling":"1.1"
 	}
 ```
 
@@ -75,5 +75,6 @@ You can also manually *show* and *hide* the view, undo the *init* completely or 
 | remove   |            | Undo the init |
 
 ## Changelog
+* 1.1: Fixed multiple trigger events at once
 * 1.0.1: Fixed for Alloy 1.0GA
 * 1.0: Initial version

--- a/app/widgets/nl.fokkezb.dynamicScrolling/widget.json
+++ b/app/widgets/nl.fokkezb.dynamicScrolling/widget.json
@@ -3,11 +3,11 @@
 	"name": "nl.fokkezb.dynamicScrolling",
 	"description" : "Easily add dynamic scrolling to your TableView.",
 	"author": "Fokke Zandbergen",
-	"version": "1.0",
+	"version": "1.1",
 	"copyright":"Copyright (c) 2012",
 	"license":"Public Domain",
 	"min-alloy-version": "1.0",
-	"min-titanium-version":"2.1",
+	"min-titanium-version":"3.0",
 	"tags":"table,view,dynamic,scrollling,load",
 	"platforms":"android,ios,mobileweb"
 }


### PR DESCRIPTION
If I scroll to the bottom, the event will trigger multiple updates.
so if offset is 50, lets say it trigger 5 times. Then 250 rows are added at once. 
