### PR TITLE
remove click event after calling detach()

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -134,6 +134,9 @@ function dettach() {
 
 	// remove listener
 	__parentSymbol.removeEventListener('scroll', onScroll);
+	
+	// remove click event listener
+	$.is.removeEventListener('click', load);
 
 	return;
 }


### PR DESCRIPTION
When detach() is called, the click event listener can be removed in addition to the scroll event.
