### PR TITLE
add the possibility to reinitialize the position

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -216,6 +216,14 @@ function _updateMessage(_message) {
   }
 }
 
+function reinitPosition() {
+  if (list) {
+    mark();
+  } else {
+    position = null;
+  }
+}
+
 exports.SUCCESS = 1;
 exports.ERROR = 0;
 exports.DONE = -1;
@@ -226,3 +234,4 @@ exports.state = state;
 exports.dettach = dettach;
 exports.init = init;
 exports.mark = mark;
+exports.reinitPosition = reinitPosition;


### PR DESCRIPTION
Hi,
First of all thx for this great widget! 
In some cases, an external action may change the content of the ListView or TableView, thus changing its contentHeight. In such a case, the infinite scroll won't work anymore, as it won't detect that the content has become smaller.

This PR adds the possibility to reinitialize the position and marker. This proves to be particularly useful when integrating with other widgets, like for instance a PullToRefresh :-)
